### PR TITLE
Add libssl-dev and pkg-config to linux provisioning

### DIFF
--- a/provision-ubuntu.sh
+++ b/provision-ubuntu.sh
@@ -65,6 +65,9 @@ git config --global push.default simple
 git config --global core.autocrlf false
 EOF
 
+#
+# install pkg-config and libssl-dev
+apt-get install -y pkg-config libssl-dev
 
 #
 # create artifacts that need to be shared with the other nodes.


### PR DESCRIPTION
Adds some dependencies needed for `evm-rs` testing on Ubuntu.

Tested on a local jenkins-vagrant environment

cc @BelfordZ @shanejonas 