### PR TITLE
Feat: fixed provisioning and llvm dependency

### DIFF
--- a/provision-ubuntu.sh
+++ b/provision-ubuntu.sh
@@ -22,6 +22,11 @@ apt-get install -y openjdk-8-jre-headless
 
 
 #
+# install LLVM for evmjit builds
+apt-get install -y llvm-7 llvm-7-dev
+
+
+#
 # add the jenkins user.
 
 groupadd --system jenkins

--- a/windows/provision-jenkins-slave.ps1
+++ b/windows/provision-jenkins-slave.ps1
@@ -41,11 +41,8 @@ Install-ChocolateyShortcut `
 
 
 # install the JRE.
-choco install -y server-jre8
+choco install -y openjdk
 Update-SessionEnvironment
-Write-Output 'Enabling the unlimited JCE policy...'
-$jceInstallPath = "$env:JAVA_HOME\jre\lib\security"
-Copy-Item "$jceInstallPath\policy\unlimited\*.jar" $jceInstallPath
 
 # restart the SSH service so it can re-read the environment (e.g. the system environment
 # variables like PATH) after we have installed all this slave node dependencies.


### PR DESCRIPTION
This PR proposes 2 changes: 
 - switch to openjdk as Java runtime on Windows as due to new Oracle policy old versions (like JDK/JRE8) are not available for the public download anymore, only developer account holder can access them. Consequently provisioning was not successful anymore. This is not connected to LLVM, this is just an issue I encountered trying to provision fresh windows slave.
 - Addition of LLVM8 dev packages to ubuntu VM for testing the evmjit branch of evm-rs